### PR TITLE
Feature/lb etcd down

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:59df7ab87ddca233bb586ff32c6feba12bf787260f6694dc45ceecea9d3e1a7e"
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1e4cf3da559842a91afcb6ea6141451e6c30c618"
+  version = "v2.1.1"
+
+[[projects]]
   digest = "1:0bc9fe59e23786a6d5f5b65d2676904d29aafcc79fa9fca4472fe0d15ee15656"
   name = "github.com/coreos/etcd"
   packages = [
@@ -236,6 +244,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Sirupsen/logrus",
+    "github.com/cenkalti/backoff",
     "github.com/coreos/etcd/mvcc/mvccpb",
     "github.com/go-test/deep",
     "github.com/satori/go.uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,3 +52,7 @@
 [[constraint]]
   name = "github.com/go-test/deep"
   version = "1.0.1"
+
+[[constraint]]
+  name = "github.com/cenkalti/backoff"
+  version = "2.1.1"

--- a/examples/lb/main.go
+++ b/examples/lb/main.go
@@ -33,7 +33,7 @@ func main() {
 		for ; ; {
 			select {
 			case e := <-ch:
-				fmt.Println("received a new lb event : ", e)
+				fmt.Println("main received a new lb event : ", e)
 			}
 		}
 	}()
@@ -43,7 +43,7 @@ func main() {
 		jobId := uuid.NewV4().String()
 		target, err := etcdLb.Target(jobId, true)
 		if err != nil {
-			log.Fatalf("getting target faield : %v", err)
+			log.Fatalf("getting target failed : %v", err)
 		}
 
 		log.Printf("got target : %s", target)

--- a/lb/etcd.go
+++ b/lb/etcd.go
@@ -355,9 +355,7 @@ func (l *etcdBakedLoadBalancer) setPauseSettle(event *LbEvent) {
 }
 
 func (l *etcdBakedLoadBalancer) monitorLbPause() {
-	stopped := l.stopped
-	changed := false
-	paused := false
+	var stopped, changed, paused bool
 	for {
 		select {
 		case e := <-l.lbSettleChan:

--- a/lb/lb.go
+++ b/lb/lb.go
@@ -1,5 +1,7 @@
 package lb
 
+import "time"
+
 type KeyLoadBalancer interface {
 	Target(key string, waitSettleTime bool) (string, error)
 	Close()
@@ -11,8 +13,25 @@ const (
 )
 
 type LbEvent struct {
-	Event  string
-	Target string
+	CreatedOn time.Time
+	Event     string
+	Target    string
+}
+
+func NewAddedEvent(target string) *LbEvent {
+	return &LbEvent{
+		CreatedOn: time.Now().UTC(),
+		Event:     TargetAdded,
+		Target:    target,
+	}
+}
+
+func NewRemovedEvent(target string) *LbEvent {
+	return &LbEvent{
+		CreatedOn: time.Now().UTC(),
+		Event:     TargetRemoved,
+		Target:    target,
+	}
 }
 
 type LbNotifier interface {

--- a/lb/retry.go
+++ b/lb/retry.go
@@ -1,0 +1,13 @@
+package lb
+
+import (
+	"github.com/cenkalti/backoff"
+	"time"
+)
+
+func RetryNormal(cb func() error) error {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = time.Second * 15
+
+	return backoff.Retry(cb, b)
+}


### PR DESCRIPTION
- when etcd is down pause the lb and try to recover the lease keepalive
- serialize the flow of internal events so we can wait more on cases where peers go up and down before lb proceeds.