### PR TITLE
Feature/add stop event

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,14 @@
   version = "v3.3.12"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:fb6b4ea21671a4a8037cccc0a582caada51b4ac550219f42b9e8ce4671bc568b"
   name = "github.com/go-test/deep"
   packages = ["."]
@@ -254,6 +262,7 @@
     "github.com/Sirupsen/logrus",
     "github.com/cenkalti/backoff",
     "github.com/coreos/etcd/mvcc/mvccpb",
+    "github.com/davecgh/go-spew/spew",
     "github.com/go-test/deep",
     "github.com/paulbellamy/ratecounter",
     "github.com/satori/go.uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,3 +60,7 @@
 [[constraint]]
   name = "github.com/paulbellamy/ratecounter"
   version = "0.2.0"
+
+[[constraint]]
+  name = "github.com/davecgh/go-spew"
+  version = "1.1.1"

--- a/examples/jobs/consumer/main.go
+++ b/examples/jobs/consumer/main.go
@@ -16,7 +16,12 @@ import (
 )
 
 func main() {
-	debugPort := "9090"
+
+	debugPort := os.Getenv("DEBUG_PORT")
+	if debugPort == "" {
+		debugPort = "9090"
+	}
+
 	go func() {
 		if err := http.ListenAndServe(fmt.Sprintf(":%s", debugPort), nil); err != nil {
 			log.Fatalf("starting the debug server %v ", err)

--- a/jobs/consumer.go
+++ b/jobs/consumer.go
@@ -116,12 +116,23 @@ func (s *streamConsumer) Start(block bool) {
 	}()
 
 	go func() {
-		ch := s.jobFilter.Notify()
+		ch := s.jobFilter.NotifyBulk()
 		for {
 			select {
-			case <-ch:
-				s.logger.Info("lb change need to re-shuffle")
-				s.requeueJobsOnLbChange()
+			case events := <-ch:
+				for _, e := range events {
+					if e.Target == lb.LbStopped {
+						s.logger.Debugf("got lb shutdown message going to trigger exit")
+						s.cancel()
+						return
+					}
+
+					if e.Event == lb.TargetRemoved {
+						s.logger.Info("lb change need to re-shuffle")
+						s.requeueJobsOnLbChange()
+						break
+					}
+				}
 			case <-s.ctx.Done():
 				return
 			}

--- a/jobs/consumer.go
+++ b/jobs/consumer.go
@@ -241,7 +241,7 @@ func (s *streamConsumer) streamHandler(event *stream.FlowEvent) error {
 	s.mu.Unlock()
 
 	if !s.isJobMine(jobId) {
-		s.logger.Debugln("this job is not mine skipping ", jobId, s.consumerID)
+		//s.logger.Debugln("this job is not mine skipping ", jobId, s.consumerID)
 		return nil
 	}
 

--- a/lb/etcd.go
+++ b/lb/etcd.go
@@ -473,7 +473,6 @@ func (l *etcdBakedLoadBalancer) monitorLbPause() {
 			if changed {
 				l.logger.Debug("setting pause to ", stopped)
 				l.setStop(stopped)
-				l.logger.Debugf("sending exit event %+v", lbEvents)
 				l.sendBulkNotification(lbEvents)
 				lbEvents = []*LbEvent{}
 			}

--- a/lb/lb.go
+++ b/lb/lb.go
@@ -10,6 +10,7 @@ type KeyLoadBalancer interface {
 const (
 	TargetAdded   = "Added"
 	TargetRemoved = "Removed"
+	LbStopped     = "LbStopped"
 )
 
 type LbEvent struct {
@@ -34,8 +35,16 @@ func NewRemovedEvent(target string) *LbEvent {
 	}
 }
 
+func NewLbStoppedEvent() *LbEvent {
+	return &LbEvent{
+		CreatedOn: time.Now().UTC(),
+		Event:     LbStopped,
+	}
+}
+
 type LbNotifier interface {
 	Notify() <-chan *LbEvent
+	NotifyBulk() <-chan []*LbEvent
 }
 
 type KeyLbNotifier interface {


### PR DESCRIPTION
- generate exit events when lb exits
- have notifyBulk method on lb which is more clever when sending events outside:
   - if same target was added or removed several times get only the last one
   - if exact amount of removals and additions happened don't send anything back.
   - send exit event when keepalive is dead on global ctx is canceled.